### PR TITLE
Check m_cursor before using it (fix #3)

### DIFF
--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -498,9 +498,10 @@ namespace ttddbg
 
 	/**********************************************************************/
 	void DebuggerManager::populatePositionChooser() {
-		// TODO: use m_engine methods to add timeline positions for each:
-		// - Thread creation / exit
-		// - Module load / unload
+		if (m_cursor == NULL) {
+			warning("The Timeline is only available while debugging.");
+			return;
+		}
 
 		if (m_positionChooser->get_count() > 0) {
 			// If the position count is > 0 even before populating, it means that

--- a/ttddbg/src/ttddbg_position_chooser.cc
+++ b/ttddbg/src/ttddbg_position_chooser.cc
@@ -86,6 +86,11 @@ namespace ttddbg {
 
 	/**********************************************************************/
 	chooser_t::cbret_t PositionChooser::ins(ssize_t n) {
+		if (m_cursor == NULL) {
+			warning("Cannot insert a new position when not in debug mode");
+			return NOTHING_CHANGED;
+		}
+
 		qstring res;
 		bool ok = ask_str(&res, 0, "Name of the new position");
 


### PR DESCRIPTION
This PR updates the position chooser the check whether `m_cursor` is `NULL` before using it to get the current position. This way, trying to insert a position while not in debug mode gives a warning instead of crashing.