### PR TITLE
Automatically hide buttons when "ttddbg" is not selected

### DIFF
--- a/ttddbg/include/ttddbg_debugger.hh
+++ b/ttddbg/include/ttddbg_debugger.hh
@@ -6,6 +6,7 @@
 #include <Windows.h>
 #include "ttddbg_logger.hh"
 #include "ttddbg_debugger_manager_interface.hh"
+#include "ttddbg_plugin.hh"
 
 namespace ttddbg 
 {

--- a/ttddbg/include/ttddbg_debugger_manager.hh
+++ b/ttddbg/include/ttddbg_debugger_manager.hh
@@ -5,6 +5,7 @@
 #include "ttddbg_logger.hh"
 #include "ttddbg_event_deque.hh"
 #include "ttddbg_position_chooser.hh"
+#include "ttddbg_plugin.hh"
 #include <deque>
 #include <memory>
 #include <Windows.h>
@@ -99,6 +100,12 @@ namespace ttddbg
 		std::filesystem::path m_targetImagePath;
 
 		/*!
+		* \brief	Reference to the Plugin.
+		*			Used to hide & show toolbar buttons
+		*/
+		std::shared_ptr<Plugin> m_plugin;
+
+		/*!
 		 * \brief	use to known if the current module is the one currently reversed
 		 * \param	module	module to process
 		 * \return	true if the TTD module is the one loaded into IDA
@@ -117,7 +124,7 @@ namespace ttddbg
 		 * \brief	ctor
 		 * \param	logger	logger use to print message
 		 */
-		explicit DebuggerManager(std::shared_ptr< ttddbg::Logger> logger, Arch arch);
+		explicit DebuggerManager(std::shared_ptr< ttddbg::Logger> logger, Arch arch, std::shared_ptr<Plugin> plugin);
 
 		/*!
 		 * \brief	First state of the automata

--- a/ttddbg/include/ttddbg_debugger_x86.hh
+++ b/ttddbg/include/ttddbg_debugger_x86.hh
@@ -19,7 +19,7 @@ namespace ttddbg
 		 * \brief	ctor
 		 * \param	logger	logger interface to print informations messages
 		 */
-		explicit DebuggerX86(std::shared_ptr<ttddbg::Logger> logger);
+		explicit DebuggerX86(std::shared_ptr<ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin);
 	};
 
 	/*!
@@ -31,7 +31,7 @@ namespace ttddbg
 		/*!
 		 * \brief	ctor
 		 */
-		explicit DebuggerManagerX86(std::shared_ptr< ttddbg::Logger> logger);
+		explicit DebuggerManagerX86(std::shared_ptr< ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin);
 
 		/*!
 		 * \brief	use to inform the debugger to read register state

--- a/ttddbg/include/ttddbg_debugger_x86_64.hh
+++ b/ttddbg/include/ttddbg_debugger_x86_64.hh
@@ -20,7 +20,7 @@ namespace ttddbg
 		 * \brief	ctor
 		 * \param	logger	logger interface to print informations messages
 		 */
-		explicit DebuggerX86_64(std::shared_ptr<ttddbg::Logger> logger);
+		explicit DebuggerX86_64(std::shared_ptr<ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin);
 	};
 
 	/*!
@@ -32,7 +32,7 @@ namespace ttddbg
 		/*!
 		 * \brief	ctor
 		 */
-		explicit DebuggerManagerX86_64(std::shared_ptr<ttddbg::Logger> logger);
+		explicit DebuggerManagerX86_64(std::shared_ptr<ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin);
 
 		/*!
 		 * \brief	use to inform the debugger to read register state

--- a/ttddbg/include/ttddbg_plugin.hh
+++ b/ttddbg/include/ttddbg_plugin.hh
@@ -5,8 +5,6 @@
 #include <idp.hpp>
 #include "ttddbg_action.hh"
 #include "ttddbg_position_chooser.hh"
-#include "single_step_icon.hh"
-#include "resume_backwards_icon.hh"
 
 namespace ttddbg 
 {
@@ -21,44 +19,20 @@ namespace ttddbg
 		 *			Use by IDA to know how to print button
 		 */
 		BackwardStateRequest m_backwardAction;
-		const action_desc_t m_backwardActionDesc = ACTION_DESC_LITERAL_PLUGMOD(
-			BackwardStateRequest::actionName,
-			BackwardStateRequest::actionLabel,
-			&m_backwardAction,
-			this,
-			nullptr,
-			nullptr,
-			load_custom_icon(resumebackwards_png, resumebackwards_png_length, "PNG")
-		);
+		const action_desc_t m_backwardActionDesc;
 
 
 		/*!
 		 * \brief	Show the timeline GUI
 		 */
 		OpenPositionChooserAction m_positionChooserAction;
-		const action_desc_t m_positionChooserActionDesc = ACTION_DESC_LITERAL_PLUGMOD(
-			OpenPositionChooserAction::actionName,
-			OpenPositionChooserAction::actionLabel,
-			&m_positionChooserAction,
-			this,
-			nullptr,
-			nullptr,
-			185			// timeline Icon
-		);
+		const action_desc_t m_positionChooserActionDesc;
 
 		/*!
 		 * \brief	single instruction pointer decrement
 		 */
 		BackwardSingleStepRequest m_backwardSingleAction;
-		const action_desc_t m_backwardSingleActionDesc = ACTION_DESC_LITERAL_PLUGMOD(
-			BackwardSingleStepRequest::actionName,
-			BackwardSingleStepRequest::actionLabel,
-			&m_backwardSingleAction,
-			this,
-			nullptr,
-			nullptr,
-			load_custom_icon(singlestep_png, singlestep_png_length, "PNG")
-		);
+		const action_desc_t m_backwardSingleActionDesc;
 
 	public:
 		/*!
@@ -75,6 +49,16 @@ namespace ttddbg
 		 * \brief main plugin function
 		 */
 		virtual bool idaapi run(size_t) override;
+
+		/*!
+		* \brief	add the actions to the Debug toolbar
+		*/
+		virtual void showActions();
+
+		/*!
+		* \brief	removes the actions from the Debug toolbar
+		*/
+		virtual void hideActions();
 	};
 }
 

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -55,12 +55,14 @@ namespace ttddbg
 	/**********************************************************************/
 	ssize_t DebuggerManager::onInit(std::string& hostname, int portNumber, std::string& password, qstring* errBuf)
 	{
+		m_plugin->showActions();
 		return DRC_OK;
 	}
 
 	/**********************************************************************/
 	ssize_t DebuggerManager::OnTermDebugger()
 	{
+		m_plugin->hideActions();
 		return DRC_OK;
 	}
 
@@ -76,7 +78,7 @@ namespace ttddbg
 
 	/**********************************************************************/
 	ssize_t DebuggerManager::onStartProcess(const char* path, const char* args, const char* startdir, uint32 dbg_proc_flags, const char* input_path, uint32 input_file_crc32, qstring* errbuf)
-	{	
+	{
 		m_isForward = true;
 		m_targetImagePath = input_path;
 

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -47,8 +47,8 @@ namespace ttddbg
 	}
 
 	/**********************************************************************/
-	DebuggerManager::DebuggerManager(std::shared_ptr<ttddbg::Logger> logger, Arch arch)
-		: m_logger(logger), m_arch{ arch }, m_isForward{ true }, m_resumeMode{ resume_mode_t::RESMOD_NONE }, m_positionChooser(new PositionChooser(m_logger)), m_nextPosition{ 0 }, m_processId(1234), m_backwardsSingleStep(false)
+	DebuggerManager::DebuggerManager(std::shared_ptr<ttddbg::Logger> logger, Arch arch, std::shared_ptr<Plugin> plugin)
+		: m_logger(logger), m_arch{ arch }, m_isForward{ true }, m_resumeMode{ resume_mode_t::RESMOD_NONE }, m_positionChooser(new PositionChooser(m_logger)), m_nextPosition{ 0 }, m_processId(1234), m_backwardsSingleStep(false), m_plugin(plugin)
 	{
 	}
 

--- a/ttddbg/src/ttddbg_debugger_x86.cc
+++ b/ttddbg/src/ttddbg_debugger_x86.cc
@@ -25,8 +25,8 @@ namespace ttddbg
 	};
 
 	/**********************************************************************/
-	DebuggerManagerX86::DebuggerManagerX86(std::shared_ptr<ttddbg::Logger> logger)
-		: DebuggerManager(logger, Arch::ARCH_32_BITS)
+	DebuggerManagerX86::DebuggerManagerX86(std::shared_ptr<ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin)
+		: DebuggerManager(logger, Arch::ARCH_32_BITS, plugin)
 	{
 
 	}
@@ -57,8 +57,8 @@ namespace ttddbg
 	}
 
 	/**********************************************************************/
-	DebuggerX86::DebuggerX86(std::shared_ptr< ttddbg::Logger> logger)
-		: Debugger(logger, std::make_unique<DebuggerManagerX86>(logger))
+	DebuggerX86::DebuggerX86(std::shared_ptr< ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin)
+		: Debugger(logger, std::make_unique<DebuggerManagerX86>(logger, plugin))
 	{
 		name = "ttddbg_x86";
 		

--- a/ttddbg/src/ttddbg_debugger_x86_64.cc
+++ b/ttddbg/src/ttddbg_debugger_x86_64.cc
@@ -33,8 +33,8 @@ namespace ttddbg
 	};
 
 	/**********************************************************************/
-	DebuggerManagerX86_64::DebuggerManagerX86_64(std::shared_ptr<ttddbg::Logger> logger)
-		: DebuggerManager(logger, Arch::ARCH_64_BITS)
+	DebuggerManagerX86_64::DebuggerManagerX86_64(std::shared_ptr<ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin)
+		: DebuggerManager(logger, Arch::ARCH_64_BITS, plugin)
 	{
 
 	}
@@ -74,8 +74,8 @@ namespace ttddbg
 
 
 	/**********************************************************************/
-	DebuggerX86_64::DebuggerX86_64(std::shared_ptr< ttddbg::Logger> logger)
-		: Debugger(logger, std::make_unique<DebuggerManagerX86_64>(logger))
+	DebuggerX86_64::DebuggerX86_64(std::shared_ptr< ttddbg::Logger> logger, std::shared_ptr<Plugin> plugin)
+		: Debugger(logger, std::make_unique<DebuggerManagerX86_64>(logger, plugin))
 	{
 		name = "ttddbg_x86_64";
 


### PR DESCRIPTION
This PR automatically hides the ttddbg buttons while the "ttddbg" debugger is not selected. I would have prefered to only show them during debugging, but I was not able to find how to do it...