### PR TITLE
Add key bindings for the actions

### DIFF
--- a/ttddbg/include/ttddbg_action.hh
+++ b/ttddbg/include/ttddbg_action.hh
@@ -14,8 +14,8 @@ namespace ttddbg
 	struct BackwardStateRequest : public action_handler_t
 	{
 		inline static const char* actionName = "ttddbg:Backward";
-		inline static const char* actionLabel = "ttddbg Backward";
-		inline static const char* actionHotkey = "F3";
+		inline static const char* actionLabel = "Continue backwards (Ctrl+F10)";
+		inline static const char* actionHotkey = "Ctrl+F10";
 
 		virtual int idaapi activate(action_activation_ctx_t*) override;
 		virtual action_state_t idaapi update(action_update_ctx_t*) override;
@@ -30,7 +30,7 @@ namespace ttddbg
 	struct BackwardSingleStepRequest : public action_handler_t
 	{
 		inline static const char* actionName = "ttddbg:BackwardSingle";
-		inline static const char* actionLabel = "Single-step backwards";
+		inline static const char* actionLabel = "Single-step backwards (Ctrl+F8)";
 		inline static const char* actionHotkey = "Ctrl+F8";
 
 		virtual int idaapi activate(action_activation_ctx_t*) override;
@@ -43,7 +43,8 @@ namespace ttddbg
 	struct OpenPositionChooserAction : public action_handler_t 
 	{
 		inline static const char* actionName = "ttddbg:ChoosePosition";
-		inline static const char* actionLabel = "Timeline";
+		inline static const char* actionLabel = "Timeline (F3)";
+		inline static const char* actionHotkey = "F3";
 
 		virtual int idaapi activate(action_activation_ctx_t*) override;
 		virtual action_state_t idaapi update(action_update_ctx_t*) override;

--- a/ttddbg/src/ttddbg_plugin.cc
+++ b/ttddbg/src/ttddbg_plugin.cc
@@ -30,7 +30,7 @@ ttddbg::Plugin::Plugin() :
 		BackwardStateRequest::actionLabel,
 		&m_backwardAction,
 		this,
-		nullptr,
+		BackwardStateRequest::actionHotkey,
 		nullptr,
 		load_custom_icon(resumebackwards_png, resumebackwards_png_length, "PNG")
 	)),
@@ -39,7 +39,7 @@ ttddbg::Plugin::Plugin() :
 		OpenPositionChooserAction::actionLabel,
 		&m_positionChooserAction,
 		this,
-		nullptr,
+		OpenPositionChooserAction::actionHotkey,
 		nullptr,
 		185			// timeline Icon
 	)),
@@ -48,7 +48,7 @@ ttddbg::Plugin::Plugin() :
 		BackwardSingleStepRequest::actionLabel,
 		&m_backwardSingleAction,
 		this,
-		nullptr,
+		BackwardSingleStepRequest::actionHotkey,
 		nullptr,
 		load_custom_icon(singlestep_png, singlestep_png_length, "PNG")
 	))


### PR DESCRIPTION
This PR fixes our action handlers' `actionHotkey` attribute not being used, and adds hotkeys to the actions. The hotkeys are as follows:
- `Ctrl+F10` for "Continue backwards" (`Ctrl+F9` was already taken)
- `Ctrl+F8` for "Single step backwards" (`Ctrl+F7` was already taken)
- `F3` for "Timeline"

The PR also adds the shortcut to each action's tooltip, so that users can discover them more easily.