### PR TITLE
Function tracing feature

### DIFF
--- a/ttddbg/CMakeLists.txt
+++ b/ttddbg/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ttddbg_STATIC_SRC
 	src/ttddbg_hooks.cc
 	src/ttddbg_tracer.cc
 	src/ttddbg_tracer_choosers.cc
+	src/ttddbg_callconv.cc
 )
 
 set(ttddbg_STATIC_INCLUDE
@@ -45,6 +46,7 @@ set(ttddbg_STATIC_INCLUDE
 	include/ttddbg_hooks.hh
 	include/ttddbg_tracer.hh
 	include/ttddbg_tracer_choosers.hh
+	include/ttddbg_callconv.hh
 )
 
 add_library(ttddbg_static STATIC ${ttddbg_STATIC_INCLUDE} ${ttddbg_STATIC_SRC})

--- a/ttddbg/CMakeLists.txt
+++ b/ttddbg/CMakeLists.txt
@@ -18,6 +18,8 @@ set(ttddbg_STATIC_SRC
 	src/ttddbg_strings.cc
 	src/ttddbg_action.cc
 	src/ttddbg_position_chooser.cc
+	src/ttddbg_hooks.cc
+	src/ttddbg_tracer.cc
 )
 
 set(ttddbg_STATIC_INCLUDE
@@ -39,6 +41,8 @@ set(ttddbg_STATIC_INCLUDE
 	include/ttddbg_x86_registers.hh
 	include/single_step_icon.hh
 	include/resume_backwards_icon.hh
+	include/ttddbg_hooks.hh
+	include/ttddbg_tracer.hh
 )
 
 add_library(ttddbg_static STATIC ${ttddbg_STATIC_INCLUDE} ${ttddbg_STATIC_SRC})

--- a/ttddbg/CMakeLists.txt
+++ b/ttddbg/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ttddbg_STATIC_SRC
 	src/ttddbg_position_chooser.cc
 	src/ttddbg_hooks.cc
 	src/ttddbg_tracer.cc
+	src/ttddbg_tracer_choosers.cc
 )
 
 set(ttddbg_STATIC_INCLUDE
@@ -43,6 +44,7 @@ set(ttddbg_STATIC_INCLUDE
 	include/resume_backwards_icon.hh
 	include/ttddbg_hooks.hh
 	include/ttddbg_tracer.hh
+	include/ttddbg_tracer_choosers.hh
 )
 
 add_library(ttddbg_static STATIC ${ttddbg_STATIC_INCLUDE} ${ttddbg_STATIC_SRC})

--- a/ttddbg/include/ttddbg_action.hh
+++ b/ttddbg/include/ttddbg_action.hh
@@ -56,7 +56,20 @@ namespace ttddbg
 	struct OpenTraceChooserAction : public action_handler_t
 	{
 		inline static const char* actionName = "ttddbg:ChooseTracedFunction";
-		inline static const char* actionLabel = "Traed functions";
+		inline static const char* actionLabel = "Traced functions";
+		inline static const char* actionHotkey = "";
+
+		virtual int idaapi activate(action_activation_ctx_t*) override;
+		virtual action_state_t idaapi update(action_update_ctx_t*) override;
+	};
+
+	/*!
+	* \brief	Action used to display the trace events chooser
+	*/
+	struct OpenTraceEventChooserAction : public action_handler_t
+	{
+		inline static const char* actionName = "ttddbg:ChooseTraceEvent";
+		inline static const char* actionLabel = "Trace events";
 		inline static const char* actionHotkey = "";
 
 		virtual int idaapi activate(action_activation_ctx_t*) override;

--- a/ttddbg/include/ttddbg_action.hh
+++ b/ttddbg/include/ttddbg_action.hh
@@ -49,6 +49,19 @@ namespace ttddbg
 		virtual int idaapi activate(action_activation_ctx_t*) override;
 		virtual action_state_t idaapi update(action_update_ctx_t*) override;
 	};
+
+	/*!
+	 * \brief	Action use to display the traced functions chooser
+	 */
+	struct OpenTraceChooserAction : public action_handler_t
+	{
+		inline static const char* actionName = "ttddbg:ChooseTracedFunction";
+		inline static const char* actionLabel = "Traed functions";
+		inline static const char* actionHotkey = "";
+
+		virtual int idaapi activate(action_activation_ctx_t*) override;
+		virtual action_state_t idaapi update(action_update_ctx_t*) override;
+	};
 }
 
 #endif

--- a/ttddbg/include/ttddbg_action.hh
+++ b/ttddbg/include/ttddbg_action.hh
@@ -75,6 +75,16 @@ namespace ttddbg
 		virtual int idaapi activate(action_activation_ctx_t*) override;
 		virtual action_state_t idaapi update(action_update_ctx_t*) override;
 	};
+
+	struct FullRunActionRequest : public action_handler_t
+	{
+		inline static const char* actionName = "ttddbg:FullRun";
+		inline static const char* actionLabel = "Full run";
+		inline static const char* actionHotkey = "";
+
+		virtual int idaapi activate(action_activation_ctx_t*) override;
+		virtual action_state_t idaapi update(action_update_ctx_t*) override;
+	};
 }
 
 #endif

--- a/ttddbg/include/ttddbg_callconv.hh
+++ b/ttddbg/include/ttddbg_callconv.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <typeinf.hpp>
+
+#include "../ttd-bindings/TTD/TTD.hpp"
+
+namespace ttddbg {
+	void* readCursorMemory(TTD::Cursor* cursor, size_t offset, size_t len);
+
+	size_t stackArgOffset(tinfo_t func_tinfo, size_t n, size_t firstStackArgNum=0);
+	DWORD32 x86_getIntArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n);
+	DWORD64 x64_getIntArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n);
+	M128A x64_getFloatArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n);
+	qstring readStringAt(TTD::Cursor* cursor, size_t offset);
+	qstring readWideStringAt(TTD::Cursor* cursor, size_t offset);
+}

--- a/ttddbg/include/ttddbg_callconv.hh
+++ b/ttddbg/include/ttddbg_callconv.hh
@@ -13,4 +13,6 @@ namespace ttddbg {
 	M128A x64_getFloatArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n);
 	qstring readStringAt(TTD::Cursor* cursor, size_t offset);
 	qstring readWideStringAt(TTD::Cursor* cursor, size_t offset);
+
+	void cat_char(qstring* out, wchar_t c);
 }

--- a/ttddbg/include/ttddbg_debugger_manager.hh
+++ b/ttddbg/include/ttddbg_debugger_manager.hh
@@ -268,6 +268,11 @@ namespace ttddbg
 		void switchWay() override;
 
 		/*!
+		*	\brief	Simulate a complete run, from start to finish
+		*/
+		void requestFullRun() override;
+
+		/*!
 		 * \brief	Request a single step debugging but in backward way ! 
 		 */
 		void requestBackwardsSingleStep() override;

--- a/ttddbg/include/ttddbg_debugger_manager.hh
+++ b/ttddbg/include/ttddbg_debugger_manager.hh
@@ -6,6 +6,7 @@
 #include "ttddbg_event_deque.hh"
 #include "ttddbg_position_chooser.hh"
 #include "ttddbg_plugin.hh"
+#include "ttddbg_tracer_choosers.hh"
 #include <deque>
 #include <memory>
 #include <Windows.h>
@@ -74,6 +75,11 @@ namespace ttddbg
 		 * \brief	State chooser window
 		 */
 		PositionChooser *m_positionChooser;
+
+		/*!
+		* \brief	Traced functions chooser
+		*/
+		TracerTraceChooser *m_traceChooser;
 
 		/*!
 		* \brief	The next position to which the cursor should go. If it is {0, 0}, continue as normal.
@@ -265,6 +271,12 @@ namespace ttddbg
 		 * \brief	Open the timeline
 		 */
 		void openPositionChooser() override;
+
+		/*
+		* \brief	Open the traced functions window
+		*/
+		void openTraceChooser() override;
+		void refreshTraceChooser();
 
 		void setNextPosition(TTD::Position newPos) override;
 

--- a/ttddbg/include/ttddbg_debugger_manager.hh
+++ b/ttddbg/include/ttddbg_debugger_manager.hh
@@ -82,6 +82,11 @@ namespace ttddbg
 		TracerTraceChooser *m_traceChooser;
 
 		/*!
+		* \brief	Trace events choosers
+		*/
+		TracerEventChooser* m_eventChooser;
+
+		/*!
 		* \brief	The next position to which the cursor should go. If it is {0, 0}, continue as normal.
 		*			If it is *not* {0, 0}, divert the control flow to set the position to this one, and set 
 		*			it to {0, 0} afterwards.
@@ -277,6 +282,12 @@ namespace ttddbg
 		*/
 		void openTraceChooser() override;
 		void refreshTraceChooser();
+
+		/*
+		*	\brief	Open the trace events window
+		*/
+		void openTraceEventsChooser() override;
+		void refreshTraceEventsChooser();
 
 		void setNextPosition(TTD::Position newPos) override;
 

--- a/ttddbg/include/ttddbg_debugger_manager_interface.hh
+++ b/ttddbg/include/ttddbg_debugger_manager_interface.hh
@@ -144,6 +144,7 @@ namespace ttddbg
 		virtual void requestBackwardsSingleStep() = 0;
 		virtual void openPositionChooser() = 0;
 		virtual void openTraceChooser() = 0;
+		virtual void openTraceEventsChooser() = 0;
 	};
 }
 

--- a/ttddbg/include/ttddbg_debugger_manager_interface.hh
+++ b/ttddbg/include/ttddbg_debugger_manager_interface.hh
@@ -143,6 +143,7 @@ namespace ttddbg
 		virtual void switchWay() = 0;
 		virtual void requestBackwardsSingleStep() = 0;
 		virtual void openPositionChooser() = 0;
+		virtual void openTraceChooser() = 0;
 	};
 }
 

--- a/ttddbg/include/ttddbg_debugger_manager_interface.hh
+++ b/ttddbg/include/ttddbg_debugger_manager_interface.hh
@@ -141,6 +141,7 @@ namespace ttddbg
 		virtual ssize_t onUpdateCallStack(thid_t tid, call_stack_t* trace) = 0;
 		
 		virtual void switchWay() = 0;
+		virtual void requestFullRun() = 0;
 		virtual void requestBackwardsSingleStep() = 0;
 		virtual void openPositionChooser() = 0;
 		virtual void openTraceChooser() = 0;

--- a/ttddbg/include/ttddbg_hooks.hh
+++ b/ttddbg/include/ttddbg_hooks.hh
@@ -20,6 +20,13 @@ namespace ttddbg {
 		size_t eventNum;
 	};
 
+	struct EditArgActionHandler : action_handler_t {
+		int activate(action_activation_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override;
+
+		size_t eventNum;
+	};
+
 
 	class Hooks {
 	public:
@@ -37,6 +44,7 @@ namespace ttddbg {
 		CopyArgActionHandler* m_copyArg2Handler;
 		CopyArgActionHandler* m_copyArg3Handler;
 		CopyArgActionHandler* m_copyArg4Handler;
+		EditArgActionHandler* m_editArgHandler;
 		int count;
 	};
 

--- a/ttddbg/include/ttddbg_hooks.hh
+++ b/ttddbg/include/ttddbg_hooks.hh
@@ -11,6 +11,16 @@ namespace ttddbg {
 		ea_t ea;
 	};
 
+	struct CopyArgActionHandler : action_handler_t {
+		CopyArgActionHandler(size_t n) : argNum(n) {};
+		int activate(action_activation_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override;
+
+		size_t argNum;
+		size_t eventNum;
+	};
+
+
 	class Hooks {
 	public:
 		Hooks();
@@ -23,6 +33,10 @@ namespace ttddbg {
 
 	private:
 		TraceActionHandler *m_actionHandler;
+		CopyArgActionHandler* m_copyArg1Handler;
+		CopyArgActionHandler* m_copyArg2Handler;
+		CopyArgActionHandler* m_copyArg3Handler;
+		CopyArgActionHandler* m_copyArg4Handler;
 		int count;
 	};
 

--- a/ttddbg/include/ttddbg_hooks.hh
+++ b/ttddbg/include/ttddbg_hooks.hh
@@ -6,23 +6,30 @@
 namespace ttddbg {
 	struct TraceActionHandler : action_handler_t {
 		int activate(action_activation_ctx_t* ctx) override;
-		action_state_t update(action_update_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override { return AST_ENABLE_ALWAYS; };
 
 		ea_t ea;
 	};
 
 	struct CopyArgActionHandler : action_handler_t {
-		CopyArgActionHandler(size_t n) : argNum(n) {};
+		CopyArgActionHandler(size_t n) : argNum(n), eventNum(0) {};
 		int activate(action_activation_ctx_t* ctx) override;
-		action_state_t update(action_update_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override { return AST_ENABLE_ALWAYS; };
 
 		size_t argNum;
 		size_t eventNum;
 	};
 
+	struct CopyReturnValueActionHandler : action_handler_t {
+		int activate(action_activation_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override { return AST_ENABLE_ALWAYS; };
+
+		size_t eventNum = 0;
+	};
+
 	struct EditArgActionHandler : action_handler_t {
 		int activate(action_activation_ctx_t* ctx) override;
-		action_state_t update(action_update_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override { return AST_ENABLE_ALWAYS; };
 
 		size_t eventNum;
 	};
@@ -44,6 +51,7 @@ namespace ttddbg {
 		CopyArgActionHandler* m_copyArg2Handler;
 		CopyArgActionHandler* m_copyArg3Handler;
 		CopyArgActionHandler* m_copyArg4Handler;
+		CopyReturnValueActionHandler* m_copyReturnHandler;
 		EditArgActionHandler* m_editArgHandler;
 		int count;
 	};

--- a/ttddbg/include/ttddbg_hooks.hh
+++ b/ttddbg/include/ttddbg_hooks.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <ida.hpp>
+#include <kernwin.hpp>
+
+namespace ttddbg {
+	struct TraceActionHandler : action_handler_t {
+		int activate(action_activation_ctx_t* ctx) override;
+		action_state_t update(action_update_ctx_t* ctx) override;
+
+		ea_t ea;
+	};
+
+	class Hooks {
+	public:
+		Hooks();
+		void registerHooks();
+
+		// UI Hooks
+		void ui_finish_populating_widget_popup(TWidget* widget, TPopupMenu* popup_handle, const action_activation_ctx_t* ctx);
+
+	private:
+		TraceActionHandler *m_actionHandler;
+		int count;
+	};
+
+	ssize_t onUINotification(void* user_data, int notification_code, va_list va);
+}

--- a/ttddbg/include/ttddbg_hooks.hh
+++ b/ttddbg/include/ttddbg_hooks.hh
@@ -14,7 +14,9 @@ namespace ttddbg {
 	class Hooks {
 	public:
 		Hooks();
+		~Hooks();
 		void registerHooks();
+		void unregisterHooks();
 
 		// UI Hooks
 		void ui_finish_populating_widget_popup(TWidget* widget, TPopupMenu* popup_handle, const action_activation_ctx_t* ctx);

--- a/ttddbg/include/ttddbg_plugin.hh
+++ b/ttddbg/include/ttddbg_plugin.hh
@@ -36,6 +36,12 @@ namespace ttddbg
 		const action_desc_t m_backwardSingleActionDesc;
 
 		/*!
+		* \brief	Show the traced function GUI
+		*/
+		OpenTraceChooserAction m_traceChooserAction;
+		const action_desc_t m_traceChooserActionDesc;
+
+		/*!
 		* \brief	Hooks manager (used to add action to context menus)
 		*/
 		Hooks hooks;

--- a/ttddbg/include/ttddbg_plugin.hh
+++ b/ttddbg/include/ttddbg_plugin.hh
@@ -22,6 +22,9 @@ namespace ttddbg
 		BackwardStateRequest m_backwardAction;
 		const action_desc_t m_backwardActionDesc;
 
+		FullRunActionRequest m_fullRunAction;
+		const action_desc_t m_fullRunActionDesc;
+
 
 		/*!
 		 * \brief	Show the timeline GUI

--- a/ttddbg/include/ttddbg_plugin.hh
+++ b/ttddbg/include/ttddbg_plugin.hh
@@ -5,6 +5,7 @@
 #include <idp.hpp>
 #include "ttddbg_action.hh"
 #include "ttddbg_position_chooser.hh"
+#include "ttddbg_hooks.hh"
 
 namespace ttddbg 
 {
@@ -33,6 +34,11 @@ namespace ttddbg
 		 */
 		BackwardSingleStepRequest m_backwardSingleAction;
 		const action_desc_t m_backwardSingleActionDesc;
+
+		/*!
+		* \brief	Hooks manager (used to add action to context menus)
+		*/
+		Hooks hooks;
 
 	public:
 		/*!

--- a/ttddbg/include/ttddbg_plugin.hh
+++ b/ttddbg/include/ttddbg_plugin.hh
@@ -42,6 +42,12 @@ namespace ttddbg
 		const action_desc_t m_traceChooserActionDesc;
 
 		/*!
+		* \brief	Show the trace events GUI
+		*/
+		OpenTraceEventChooserAction m_traceEventChooserAction;
+		const action_desc_t m_traceEventChooserActionDesc;
+
+		/*!
 		* \brief	Hooks manager (used to add action to context menus)
 		*/
 		Hooks hooks;

--- a/ttddbg/include/ttddbg_tracer.hh
+++ b/ttddbg/include/ttddbg_tracer.hh
@@ -15,6 +15,8 @@ namespace ttddbg {
 	struct FunctionInvocation {
 		func_t* func;
 		TTD::Position pos;
+
+		std::vector<qstring> args;
 	};
 
 	class FunctionTracer {
@@ -23,15 +25,18 @@ namespace ttddbg {
 		static void destroy();
 
 		void setCursor(std::shared_ptr<TTD::Cursor>);
+		void setEngine(TTD::ReplayEngine);
 		void traceFunction(func_t*);
 		void removeTrace(size_t n);
+		void removeEvent(size_t n);
 
 		bool isTraced(func_t*);
 		bool isEATraced(ea_t);
 
-		void recordCall(func_t* func, TTD::Position pos);
+		void recordCall(FunctionInvocation);
 
 		void setNewTraceCallback(std::function<void(func_t*)>);
+		void setNewEventCallback(std::function<void(FunctionInvocation)>);
 
 		// View into the list of traced functions
 		size_t countTraced();
@@ -40,12 +45,16 @@ namespace ttddbg {
 		// View into the list of events
 		size_t countEvents();
 		FunctionInvocation eventAt(int i);
+		void copyArgumentAddress(size_t nevent, size_t narg);
 
 	private:
+		void sortEvents();
+
 		FunctionTracer();
 		static FunctionTracer* c_instance;
 		
 		std::shared_ptr<TTD::Cursor> m_cursor;
+		TTD::ReplayEngine m_engine;
 		std::vector<ea_t> m_traces;
 
 		std::vector<FunctionInvocation> m_events;

--- a/ttddbg/include/ttddbg_tracer.hh
+++ b/ttddbg/include/ttddbg_tracer.hh
@@ -50,6 +50,7 @@ namespace ttddbg {
 		size_t countEvents();
 		FunctionInvocation eventAt(int i);
 		void copyArgumentAddress(size_t nevent, size_t narg);
+		void copyReturnValue(size_t nevent);
 
 	private:
 		void sortEvents();

--- a/ttddbg/include/ttddbg_tracer.hh
+++ b/ttddbg/include/ttddbg_tracer.hh
@@ -3,6 +3,7 @@
 #include <vector>
 #include <memory>
 #include <functional>
+#include <mutex>
 
 #include <pro.h>
 #include <funcs.hpp>
@@ -58,8 +59,10 @@ namespace ttddbg {
 		FunctionTracer();
 		static FunctionTracer* c_instance;
 		
-		std::shared_ptr<TTD::Cursor> m_cursor;
 		TTD::ReplayEngine m_engine;
+
+		std::mutex m_safeTraces;
+		std::mutex m_safeEvents;
 
 		std::vector<ea_t> m_traces;
 		std::vector<FunctionInvocation> m_events;

--- a/ttddbg/include/ttddbg_tracer.hh
+++ b/ttddbg/include/ttddbg_tracer.hh
@@ -15,6 +15,7 @@ namespace ttddbg {
 	struct FunctionInvocation {
 		func_t* func;
 		TTD::Position pos;
+		bool is_return = false;
 
 		std::vector<qstring> args;
 	};
@@ -34,9 +35,12 @@ namespace ttddbg {
 		bool isEATraced(ea_t);
 
 		void recordCall(FunctionInvocation);
+		void recordRet(ea_t func_addr, TTD::Position);
 
 		void setNewTraceCallback(std::function<void(func_t*)>);
 		void setNewEventCallback(std::function<void(FunctionInvocation)>);
+
+		void setClipboardContent(qstring);
 
 		// View into the list of traced functions
 		size_t countTraced();
@@ -55,8 +59,8 @@ namespace ttddbg {
 		
 		std::shared_ptr<TTD::Cursor> m_cursor;
 		TTD::ReplayEngine m_engine;
-		std::vector<ea_t> m_traces;
 
+		std::vector<ea_t> m_traces;
 		std::vector<FunctionInvocation> m_events;
 
 		std::function<void(func_t*)> m_cbNewTrace;

--- a/ttddbg/include/ttddbg_tracer.hh
+++ b/ttddbg/include/ttddbg_tracer.hh
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <memory>
+#include <functional>
 
 #include <pro.h>
 #include <funcs.hpp>
@@ -9,23 +10,47 @@
 #include "../ttd-bindings/TTD/TTD.hpp"
 
 namespace ttddbg {
-
+	// FunctionInvocation represents a function call event,
+	// recorded by the tracer.
+	struct FunctionInvocation {
+		func_t* func;
+		TTD::Position pos;
+	};
 
 	class FunctionTracer {
 	public:
 		static FunctionTracer* getInstance();
+		static void destroy();
 
 		void setCursor(std::shared_ptr<TTD::Cursor>);
 		void traceFunction(func_t*);
+		void removeTrace(size_t n);
 
 		bool isTraced(func_t*);
 		bool isEATraced(ea_t);
 
+		void recordCall(func_t* func, TTD::Position pos);
+
+		void setNewTraceCallback(std::function<void(func_t*)>);
+
+		// View into the list of traced functions
+		size_t countTraced();
+		func_t* funcAt(int i);
+
+		// View into the list of events
+		size_t countEvents();
+		FunctionInvocation eventAt(int i);
+
 	private:
 		FunctionTracer();
-		static inline FunctionTracer* c_instance;
+		static FunctionTracer* c_instance;
 		
 		std::shared_ptr<TTD::Cursor> m_cursor;
 		std::vector<ea_t> m_traces;
+
+		std::vector<FunctionInvocation> m_events;
+
+		std::function<void(func_t*)> m_cbNewTrace;
+		std::function<void(FunctionInvocation)> m_cbNewEvent;
 	};
 }

--- a/ttddbg/include/ttddbg_tracer.hh
+++ b/ttddbg/include/ttddbg_tracer.hh
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include <pro.h>
+#include <funcs.hpp>
+
+#include "../ttd-bindings/TTD/TTD.hpp"
+
+namespace ttddbg {
+
+
+	class FunctionTracer {
+	public:
+		static FunctionTracer* getInstance();
+
+		void setCursor(std::shared_ptr<TTD::Cursor>);
+		void traceFunction(func_t*);
+
+		bool isTraced(func_t*);
+		bool isEATraced(ea_t);
+
+	private:
+		FunctionTracer();
+		static inline FunctionTracer* c_instance;
+		
+		std::shared_ptr<TTD::Cursor> m_cursor;
+		std::vector<ea_t> m_traces;
+	};
+}

--- a/ttddbg/include/ttddbg_tracer_choosers.hh
+++ b/ttddbg/include/ttddbg_tracer_choosers.hh
@@ -16,6 +16,13 @@ namespace ttddbg {
 	};
 
 	class TracerEventChooser : public chooser_t {
+	public:
+		TracerEventChooser();
 
+		// Overrides
+		size_t get_count() const override;
+		void get_row(qstrvec_t* out, int* out_icon, chooser_item_attrs_t* out_attrs, size_t n) const override;
+		ea_t get_ea(size_t n) const override;
+		chooser_t::cbret_t del(size_t) override;
 	};
 }

--- a/ttddbg/include/ttddbg_tracer_choosers.hh
+++ b/ttddbg/include/ttddbg_tracer_choosers.hh
@@ -13,6 +13,7 @@ namespace ttddbg {
 		void get_row(qstrvec_t* out, int* out_icon, chooser_item_attrs_t* out_attrs, size_t n) const override;
 		//ea_t get_ea(size_t) const override;
 		cbret_t del(size_t) override;
+		chooser_t::cbret_t ins(ssize_t) override;
 	};
 
 	class TracerEventChooser : public chooser_t {

--- a/ttddbg/include/ttddbg_tracer_choosers.hh
+++ b/ttddbg/include/ttddbg_tracer_choosers.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <pro.h>
+#include <kernwin.hpp>
+
+namespace ttddbg {
+	class TracerTraceChooser : public chooser_t {
+	public:
+		TracerTraceChooser();
+
+		// Overrides
+		size_t get_count() const override;
+		void get_row(qstrvec_t* out, int* out_icon, chooser_item_attrs_t* out_attrs, size_t n) const override;
+		//ea_t get_ea(size_t) const override;
+		cbret_t del(size_t) override;
+	};
+
+	class TracerEventChooser : public chooser_t {
+
+	};
+}

--- a/ttddbg/src/ttddbg_action.cc
+++ b/ttddbg/src/ttddbg_action.cc
@@ -80,4 +80,19 @@ namespace ttddbg
 	action_state_t idaapi ttddbg::OpenTraceEventChooserAction::update(action_update_ctx_t*) {
 		return AST_ENABLE_ALWAYS;
 	}
+
+	/**********************************************************************/
+	int idaapi ttddbg::FullRunActionRequest::activate(action_activation_ctx_t*) {
+		if (dbg != nullptr)
+		{
+			static_cast<ttddbg::Debugger*>(dbg)->getManager().requestFullRun();
+		}
+		return false;
+	}
+
+	/**********************************************************************/
+	action_state_t idaapi ttddbg::FullRunActionRequest::update(action_update_ctx_t*) {
+		return AST_ENABLE_ALWAYS;
+	}
+
 }

--- a/ttddbg/src/ttddbg_action.cc
+++ b/ttddbg/src/ttddbg_action.cc
@@ -52,4 +52,18 @@ namespace ttddbg
 	action_state_t idaapi ttddbg::OpenPositionChooserAction::update(action_update_ctx_t*) {
 		return AST_ENABLE_ALWAYS;
 	}
+
+	/**********************************************************************/
+	int idaapi ttddbg::OpenTraceChooserAction::activate(action_activation_ctx_t*) {
+		if (dbg != nullptr)
+		{
+			static_cast<ttddbg::Debugger*>(dbg)->getManager().openTraceChooser();
+		}
+		return false;
+	}
+
+	/**********************************************************************/
+	action_state_t idaapi ttddbg::OpenTraceChooserAction::update(action_update_ctx_t*) {
+		return AST_ENABLE_ALWAYS;
+	}
 }

--- a/ttddbg/src/ttddbg_action.cc
+++ b/ttddbg/src/ttddbg_action.cc
@@ -66,4 +66,18 @@ namespace ttddbg
 	action_state_t idaapi ttddbg::OpenTraceChooserAction::update(action_update_ctx_t*) {
 		return AST_ENABLE_ALWAYS;
 	}
+
+	/**********************************************************************/
+	int idaapi ttddbg::OpenTraceEventChooserAction::activate(action_activation_ctx_t*) {
+		if (dbg != nullptr)
+		{
+			static_cast<ttddbg::Debugger*>(dbg)->getManager().openTraceEventsChooser();
+		}
+		return false;
+	}
+
+	/**********************************************************************/
+	action_state_t idaapi ttddbg::OpenTraceEventChooserAction::update(action_update_ctx_t*) {
+		return AST_ENABLE_ALWAYS;
+	}
 }

--- a/ttddbg/src/ttddbg_callconv.cc
+++ b/ttddbg/src/ttddbg_callconv.cc
@@ -102,7 +102,7 @@ namespace ttddbg {
 		int i = 0;
 
 		while (c != 0) {
-			str.cat_sprnt("%c", c);
+			cat_char(&str, c);
 			i++;
 			c = *(char*)readCursorMemory(cursor, offset+i, 1);
 		}
@@ -116,11 +116,33 @@ namespace ttddbg {
 		int i = 0;
 
 		while (c != 0) {
-			str.cat_sprnt("%c", c);
+			cat_char(&str, c);
 			i += 2;
 			c = *(wchar_t*)readCursorMemory(cursor, offset+i, 2);
 		}
 
 		return str;
+	}
+
+	void cat_char(qstring* out, wchar_t c) {
+		switch (c) {
+		case '\n':
+			out->cat_sprnt("\\n");
+			break;
+		case '\r':
+			out->cat_sprnt("\\r");
+			break;
+		case '\t':
+			out->cat_sprnt("\\t");
+			break;
+		default:
+			if ((c >> 8) == 0) {
+				// 8-bit char
+				out->cat_sprnt("%c", c & 0xFF);
+			}
+			else {
+				out->cat_sprnt("%lc", c);
+			}
+		}
 	}
 }

--- a/ttddbg/src/ttddbg_callconv.cc
+++ b/ttddbg/src/ttddbg_callconv.cc
@@ -104,7 +104,7 @@ namespace ttddbg {
 		while (c != 0) {
 			str.cat_sprnt("%c", c);
 			i++;
-			c = *(char*)readCursorMemory(cursor, offset, 1);
+			c = *(char*)readCursorMemory(cursor, offset+i, 1);
 		}
 
 		return str;
@@ -118,7 +118,7 @@ namespace ttddbg {
 		while (c != 0) {
 			str.cat_sprnt("%c", c);
 			i += 2;
-			c = *(wchar_t*)readCursorMemory(cursor, offset, 2);
+			c = *(wchar_t*)readCursorMemory(cursor, offset+i, 2);
 		}
 
 		return str;

--- a/ttddbg/src/ttddbg_callconv.cc
+++ b/ttddbg/src/ttddbg_callconv.cc
@@ -1,0 +1,126 @@
+#include "ttddbg_callconv.hh"
+
+#include <typeinf.hpp>
+
+namespace ttddbg {
+	void* readCursorMemory(TTD::Cursor* cursor, size_t offset, size_t len) {
+		TTD::MemoryBuffer* buf = cursor->QueryMemoryBuffer(offset, len);
+		return buf->data;
+	}
+
+	// Get the offset from ESP to access a specific function argument stored on the stack.
+	// Information about argument sizes is fetched from the IDA database.
+	// "firstStackArgNum" is the index of the first argument stored on the stack.
+	size_t stackArgOffset(tinfo_t func_tinfo, size_t n, size_t firstStackArgNum) {
+		size_t espOffset = 0;
+		tinfo_t arg;
+		for (size_t i = firstStackArgNum; i < n; i++) {
+			arg = func_tinfo.get_nth_arg(i);
+			espOffset += arg.get_size();
+		}
+
+		return espOffset;
+	}
+
+	DWORD32 x86_getIntArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n) {
+		func_type_data_t funcdata;
+		tinfo.get_func_details(&funcdata);
+		cm_t cc = funcdata.get_cc();
+
+		size_t firstStackArg = 0;
+
+		if (cc == CM_CC_FASTCALL && n < 2) {
+			DWORD32 registers[2] = { cursor->GetContextx86()->Ecx,  cursor->GetContextx86()->Edx };
+			return registers[n];
+		}
+		else if (cc == CM_CC_FASTCALL) {
+			firstStackArg = 2;
+		}
+		else if (cc == CM_CC_STDCALL || cc == CM_CC_CDECL) {
+			// We are *before* the function prologue, and *before* the "call" instruction is actually executed so:
+			// - ebp is still pointing to the caller's stack base
+			// - the stack contains (no return address, because no "call"):
+			//   - arg1   <--- esp
+			//   - arg2
+			size_t espOffset = stackArgOffset(tinfo, n, firstStackArg);
+			DWORD32 esp = cursor->GetContextx86()->Esp;
+
+			return *(DWORD32*)readCursorMemory(cursor, esp + espOffset, 4);
+		}
+
+		return -1;
+	}
+
+	DWORD64 x64_getIntArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n) {
+		func_type_data_t funcdata;
+		tinfo.get_func_details(&funcdata);
+		cm_t cc = funcdata.get_cc();
+
+		if (cc != CM_CC_FASTCALL) {
+			msg("[ttddbg] [!!] non-fastcall functions are not supported under x64");
+			return -1;
+		}
+
+		if (n < 4) {
+			DWORD64 registers[4] = { cursor->GetContextx86_64()->Rcx,  cursor->GetContextx86_64()->Rdx, cursor->GetContextx86_64()->R8, cursor->GetContextx86_64()->R9 };
+			return registers[n];
+		}
+		else {
+			size_t rspOffset = stackArgOffset(tinfo, n, 4);
+			DWORD64 rsp = cursor->GetContextx86_64()->Rsp;
+
+			return *(DWORD64*)readCursorMemory(cursor, rsp + rspOffset, 8);
+		}
+
+		return -1;
+	}
+
+	M128A x64_getFloatArg(TTD::Cursor* cursor, tinfo_t tinfo, size_t n) {
+		func_type_data_t funcdata;
+		tinfo.get_func_details(&funcdata);
+		cm_t cc = funcdata.get_cc();
+
+		if (cc != CM_CC_FASTCALL) {
+			msg("[ttddbg] [!!] non-fastcall functions are not supported under x64\n");
+			return M128A{ 0 };
+		}
+
+		if (n < 4) {
+			M128A registers[4] = { cursor->GetContextx86_64()->Xmm0,  cursor->GetContextx86_64()->Xmm1, cursor->GetContextx86_64()->Xmm2, cursor->GetContextx86_64()->Xmm3 };
+			return registers[n];
+		}
+		else {
+			// TODO: Need different handling depending on whether it's a float or double (different size on the stack)
+		}
+
+		return M128A{ 0 };
+	}
+
+	qstring readStringAt(TTD::Cursor* cursor, size_t offset) {
+		qstring str;
+		char c = *(char*)readCursorMemory(cursor, offset, 1);
+		int i = 0;
+
+		while (c != 0) {
+			str.cat_sprnt("%c", c);
+			i++;
+			c = *(char*)readCursorMemory(cursor, offset, 1);
+		}
+
+		return str;
+	}
+
+	qstring readWideStringAt(TTD::Cursor* cursor, size_t offset) {
+		qstring str;
+		wchar_t c = *(wchar_t*)readCursorMemory(cursor, offset, 2);
+		int i = 0;
+
+		while (c != 0) {
+			str.cat_sprnt("%c", c);
+			i += 2;
+			c = *(wchar_t*)readCursorMemory(cursor, offset, 2);
+		}
+
+		return str;
+	}
+}

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -492,6 +492,8 @@ namespace ttddbg
 	/**********************************************************************/
 	void DebuggerManager::requestFullRun()
 	{
+		show_wait_box("HIDECANCEL\nPlease wait...");
+
 		TTD::Position first = *m_engine.GetFirstPosition();
 		TTD::Position last = *m_engine.GetLastPosition();
 
@@ -508,11 +510,16 @@ namespace ttddbg
 			m_cursor->ReplayForward(&rresult, &last, 1);
 			cur = *m_cursor->GetPosition();
 			count++;
+
+			if (count % 1000 == 0) {
+				replace_wait_box("HIDECANCEL\nPlease wait...%d iterations done", count);
+			}
 		}
 
 		m_cursor->SetPosition(&old);
+		hide_wait_box();
 
-		msg("[ttddbg] full run completed wih %d iterations\n", count);
+		msg("[ttddbg] full run completed with %d iterations\n", count);
 	}
 
 	/**********************************************************************/

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -512,7 +512,7 @@ namespace ttddbg
 			count++;
 
 			if (count % 1000 == 0) {
-				replace_wait_box("Please wait...%d iterations done\n%d / %d (%d%%)", count, cur.Major, last.Major, (int)(((double)cur.Major/(double)last.Major)*100.0));
+				replace_wait_box("%d iterations done (%d%%)", count, (int)(((double)cur.Major/(double)last.Major)*100.0));
 
 				if (user_cancelled()) {
 					break;

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -49,7 +49,7 @@ namespace ttddbg
 
 	/**********************************************************************/
 	DebuggerManager::DebuggerManager(std::shared_ptr<ttddbg::Logger> logger, Arch arch, Plugin *plugin)
-		: m_logger(logger), m_arch{ arch }, m_isForward{ true }, m_resumeMode{ resume_mode_t::RESMOD_NONE }, m_positionChooser(new PositionChooser(m_logger)), m_nextPosition{ 0 }, m_processId(1234), m_backwardsSingleStep(false), m_plugin(plugin)
+		: m_logger(logger), m_arch{ arch }, m_isForward{ true }, m_resumeMode{ resume_mode_t::RESMOD_NONE }, m_positionChooser(new PositionChooser(m_logger)), m_traceChooser(new TracerTraceChooser()), m_nextPosition{0}, m_processId(1234), m_backwardsSingleStep(false), m_plugin(plugin)
 	{
 	}
 
@@ -64,6 +64,7 @@ namespace ttddbg
 	ssize_t DebuggerManager::OnTermDebugger()
 	{
 		m_plugin->hideActions();
+		FunctionTracer::destroy();
 		return DRC_OK;
 	}
 
@@ -131,6 +132,9 @@ namespace ttddbg
 
 		// Init the function tracer
 		FunctionTracer::getInstance()->setCursor(m_cursor);
+		FunctionTracer::getInstance()->setNewTraceCallback([this](func_t* func) {
+			this->refreshTraceChooser();
+		});
 
 		m_events.addProcessStartEvent(
 			m_processId,
@@ -494,6 +498,19 @@ namespace ttddbg
 	void DebuggerManager::openPositionChooser() {
 		if (m_positionChooser != nullptr) {
 			m_positionChooser->choose();
+		}
+	}
+
+	/**********************************************************************/
+	void DebuggerManager::openTraceChooser() {
+		if (m_traceChooser != nullptr) {
+			m_traceChooser->choose();
+		}
+	}
+
+	void DebuggerManager::refreshTraceChooser() {
+		if (m_traceChooser != nullptr) {
+			m_traceChooser->choose();
 		}
 	}
 

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -7,6 +7,7 @@
 #include <idp.hpp>
 #include <ida.hpp>
 #include <segment.hpp>
+#include <dbg.hpp>
 
 namespace ttddbg
 {
@@ -486,6 +487,32 @@ namespace ttddbg
 	void DebuggerManager::switchWay()
 	{
 		m_isForward = !m_isForward;
+	}
+
+	/**********************************************************************/
+	void DebuggerManager::requestFullRun()
+	{
+		TTD::Position first = *m_engine.GetFirstPosition();
+		TTD::Position last = *m_engine.GetLastPosition();
+
+		TTD::Position old = *m_cursor->GetPosition();
+		
+		FunctionTracer::getInstance()->setCursor(m_cursor);
+		m_cursor->SetPosition(&first);
+		
+		TTD::Position cur = first;
+		size_t count = 0;
+		TTD::TTD_Replay_ICursorView_ReplayResult rresult;
+
+		while (cur.Major != last.Major || cur.Minor != last.Minor) {
+			m_cursor->ReplayForward(&rresult, &last, 1);
+			cur = *m_cursor->GetPosition();
+			count++;
+		}
+
+		m_cursor->SetPosition(&old);
+
+		msg("[ttddbg] full run completed wih %d iterations\n", count);
 	}
 
 	/**********************************************************************/

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include "ttddbg_debugger_manager.hh"
 #include "ttddbg_strings.hh"
+#include "ttddbg_tracer.hh"
 #include <idp.hpp>
 #include <ida.hpp>
 #include <segment.hpp>
@@ -127,6 +128,9 @@ namespace ttddbg
 		
 		// Init cursor at the first position
 		m_cursor->SetPosition(m_engine.GetFirstPosition());
+
+		// Init the function tracer
+		FunctionTracer::getInstance()->setCursor(m_cursor);
 
 		m_events.addProcessStartEvent(
 			m_processId,

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -512,7 +512,11 @@ namespace ttddbg
 			count++;
 
 			if (count % 1000 == 0) {
-				replace_wait_box("HIDECANCEL\nPlease wait...%d iterations done", count);
+				replace_wait_box("Please wait...%d iterations done\n%d / %d (%d%%)", count, cur.Major, last.Major, (int)(((double)cur.Major/(double)last.Major)*100.0));
+
+				if (user_cancelled()) {
+					break;
+				}
 			}
 		}
 

--- a/ttddbg/src/ttddbg_hooks.cc
+++ b/ttddbg/src/ttddbg_hooks.cc
@@ -1,0 +1,83 @@
+#include "ttddbg_hooks.hh"
+#include "ttddbg_tracer.hh"
+
+#include <kernwin.hpp>
+#include <funcs.hpp>
+
+namespace ttddbg {
+	Hooks::Hooks() {
+		count = 0;
+		m_actionHandler = new TraceActionHandler();
+
+		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_traceFunc", "Trace function in TTD", m_actionHandler, nullptr, "", "", -1, 0));
+	}
+
+	void Hooks::registerHooks() {
+		bool ok = hook_to_notification_point(HT_UI, &onUINotification, this);
+		if (!ok) {
+			msg("Error hooking to UI notifications\n");
+		}
+	}
+
+	ssize_t onUINotification(void* user_data, int notification_code, va_list va) {
+		Hooks* obj = (Hooks*)user_data;
+
+		if (notification_code == ::ui_finish_populating_widget_popup) {
+			TWidget* widget = va_arg(va, TWidget*);
+			TPopupMenu* popup_handle = va_arg(va, TPopupMenu*);
+			const action_activation_ctx_t* ctx = va_arg(va, action_activation_ctx_t*);
+
+			obj->ui_finish_populating_widget_popup(widget, popup_handle, ctx);
+		}
+
+		return 0;
+	}
+
+	void Hooks::ui_finish_populating_widget_popup(TWidget* widget, TPopupMenu* popup_handle, const action_activation_ctx_t* ctx) {
+		// Case 1 : "Module: " choosers, containing a bunch of DLL functions
+		if (ctx->widget_type == BWN_CHOOSER && ctx->widget_title.length() > 8 && ctx->widget_title.substr(0, 8) == "Module: ") {
+
+			if (ctx->chooser_selection.size() != 1) {
+				return;
+			}
+
+			uval_t sel = ctx->chooser_selection.at(0);
+			ea_t ea = ctx->source.chooser->get_ea(sel);
+
+			m_actionHandler->ea = ea;
+			attach_action_to_popup(nullptr, popup_handle, "ttddbg_traceFunc", nullptr, SETMENU_FIRST);
+
+			return;
+		}
+
+		// Case 2 : a function from the "Functions" window
+		if (ctx->widget_type == BWN_FUNCS) {
+			if (ctx->chooser_selection.size() != 1) {
+				return;
+			}
+
+			uval_t sel = ctx->chooser_selection.at(0);
+			ea_t ea = ctx->source.chooser->get_ea(sel);
+
+			m_actionHandler->ea = ea;
+			attach_action_to_popup(nullptr, popup_handle, "ttddbg_traceFunc", nullptr, SETMENU_FIRST);
+
+			return;
+		}
+	}
+
+	
+
+	/***************************************************************************/
+	int TraceActionHandler::activate(action_activation_ctx_t* ctx) {
+		func_t* func = get_func(this->ea);
+		FunctionTracer::getInstance()->traceFunction(func);
+		return 0;
+
+	}
+
+
+	action_state_t TraceActionHandler::update(action_update_ctx_t* ctx) {
+		return AST_ENABLE_ALWAYS;
+	}
+}

--- a/ttddbg/src/ttddbg_hooks.cc
+++ b/ttddbg/src/ttddbg_hooks.cc
@@ -12,10 +12,21 @@ namespace ttddbg {
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_traceFunc", "Trace function in TTD", m_actionHandler, nullptr, "", "", -1, 0));
 	}
 
+	Hooks::~Hooks() {
+		unregister_action("ttddbg_traceFunc");
+	}
+
 	void Hooks::registerHooks() {
 		bool ok = hook_to_notification_point(HT_UI, &onUINotification, this);
 		if (!ok) {
 			msg("Error hooking to UI notifications\n");
+		}
+	}
+
+	void Hooks::unregisterHooks() {
+		bool ok = unhook_from_notification_point(HT_UI, &onUINotification, this);
+		if (!ok) {
+			msg("Error unhooking from UI notifications\n");
 		}
 	}
 
@@ -71,6 +82,10 @@ namespace ttddbg {
 	/***************************************************************************/
 	int TraceActionHandler::activate(action_activation_ctx_t* ctx) {
 		func_t* func = get_func(this->ea);
+		if (func == nullptr) {
+			warning("Cannot trace this function: function not found");
+			return 0;
+		}
 		FunctionTracer::getInstance()->traceFunction(func);
 		return 0;
 

--- a/ttddbg/src/ttddbg_hooks.cc
+++ b/ttddbg/src/ttddbg_hooks.cc
@@ -12,12 +12,14 @@ namespace ttddbg {
 		m_copyArg2Handler = new CopyArgActionHandler(1);
 		m_copyArg3Handler = new CopyArgActionHandler(2);
 		m_copyArg4Handler = new CopyArgActionHandler(3);
+		//m_editArgHandler = new EditArgActionHandler();
 
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_traceFunc", "Trace function in TTD", m_actionHandler, nullptr, "", "", -1, 0));
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg1", "Copy arg1 address", m_copyArg1Handler, nullptr, "", "", -1, 0));
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg2", "Copy arg2 address", m_copyArg2Handler, nullptr, "", "", -1, 0));
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg3", "Copy arg3 address", m_copyArg3Handler, nullptr, "", "", -1, 0));
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg4", "Copy arg4 address", m_copyArg4Handler, nullptr, "", "", -1, 0));
+		//register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_editArg", "Edit an argument...", m_editArgHandler, nullptr, "", "", -1, 0));
 	}
 
 	Hooks::~Hooks() {
@@ -57,6 +59,8 @@ namespace ttddbg {
 	}
 
 	void Hooks::ui_finish_populating_widget_popup(TWidget* widget, TPopupMenu* popup_handle, const action_activation_ctx_t* ctx) {
+		//msg("[hooks] Type: %d | Title: %s\n", ctx->widget_type, ctx->widget_title.c_str());
+		
 		// Case 1 : "Module: " choosers, containing a bunch of DLL functions
 		if (ctx->widget_type == BWN_CHOOSER && ctx->widget_title.length() > 8 && ctx->widget_title.substr(0, 8) == "Module: ") {
 
@@ -102,8 +106,6 @@ namespace ttddbg {
 
 			return;
 		}
-
-		msg("[hooks] Type: %d | Title: %s\n", ctx->widget_type, ctx->widget_title.c_str());
 
 		// Case 4: We're in the "Tracing events" window: add option to copy argument addresses
 		if (ctx->widget_title == "Tracing events") {

--- a/ttddbg/src/ttddbg_hooks.cc
+++ b/ttddbg/src/ttddbg_hooks.cc
@@ -8,12 +8,24 @@ namespace ttddbg {
 	Hooks::Hooks() {
 		count = 0;
 		m_actionHandler = new TraceActionHandler();
+		m_copyArg1Handler = new CopyArgActionHandler(0);
+		m_copyArg2Handler = new CopyArgActionHandler(1);
+		m_copyArg3Handler = new CopyArgActionHandler(2);
+		m_copyArg4Handler = new CopyArgActionHandler(3);
 
 		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_traceFunc", "Trace function in TTD", m_actionHandler, nullptr, "", "", -1, 0));
+		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg1", "Copy arg1 address", m_copyArg1Handler, nullptr, "", "", -1, 0));
+		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg2", "Copy arg2 address", m_copyArg2Handler, nullptr, "", "", -1, 0));
+		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg3", "Copy arg3 address", m_copyArg3Handler, nullptr, "", "", -1, 0));
+		register_action(ACTION_DESC_LITERAL_OWNER("ttddbg_copyArg4", "Copy arg4 address", m_copyArg4Handler, nullptr, "", "", -1, 0));
 	}
 
 	Hooks::~Hooks() {
 		unregister_action("ttddbg_traceFunc");
+		unregister_action("ttddbg_copyArg1");
+		unregister_action("ttddbg_copyArg2");
+		unregister_action("ttddbg_copyArg3");
+		unregister_action("ttddbg_copyArg4");
 	}
 
 	void Hooks::registerHooks() {
@@ -75,6 +87,53 @@ namespace ttddbg {
 
 			return;
 		}
+
+		// Case 3 : a function from the "Imports" window
+		if (ctx->widget_type == BWN_IMPORTS) {
+			if (ctx->chooser_selection.size() != 1) {
+				return;
+			}
+
+			uval_t sel = ctx->chooser_selection.at(0);
+			ea_t ea = ctx->source.chooser->get_ea(sel);
+
+			m_actionHandler->ea = ea;
+			attach_action_to_popup(nullptr, popup_handle, "ttddbg_traceFunc", nullptr, SETMENU_FIRST);
+
+			return;
+		}
+
+		msg("[hooks] Type: %d | Title: %s\n", ctx->widget_type, ctx->widget_title.c_str());
+
+		// Case 4: We're in the "Tracing events" window: add option to copy argument addresses
+		if (ctx->widget_title == "Tracing events") {
+			if (ctx->chooser_selection.size() != 1) {
+				return;
+			}
+
+			uval_t sel = ctx->chooser_selection.at(0);
+			m_copyArg1Handler->eventNum = sel;
+			m_copyArg2Handler->eventNum = sel;
+			m_copyArg3Handler->eventNum = sel;
+			m_copyArg4Handler->eventNum = sel;
+
+			size_t nargs = FunctionTracer::getInstance()->eventAt(sel).args.size();
+
+			if (nargs > 0) {
+				attach_action_to_popup(nullptr, popup_handle, "ttddbg_copyArg1", nullptr, 0);
+			}
+			if (nargs > 1) {
+				attach_action_to_popup(nullptr, popup_handle, "ttddbg_copyArg2", nullptr, 0);
+			}
+			if (nargs > 2) {
+				attach_action_to_popup(nullptr, popup_handle, "ttddbg_copyArg3", nullptr, 0);
+			}
+			if (nargs > 3) {
+				attach_action_to_popup(nullptr, popup_handle, "ttddbg_copyArg4", nullptr, 0);
+			}
+			
+			return;
+		}
 	}
 
 	
@@ -93,6 +152,16 @@ namespace ttddbg {
 
 
 	action_state_t TraceActionHandler::update(action_update_ctx_t* ctx) {
+		return AST_ENABLE_ALWAYS;
+	}
+
+	/***************************************************************************/
+	int CopyArgActionHandler::activate(action_activation_ctx_t* ctx) {
+		FunctionTracer::getInstance()->copyArgumentAddress(eventNum, argNum);
+		return 0;
+	}
+
+	action_state_t CopyArgActionHandler::update(action_activation_ctx_t* ctx) {
 		return AST_ENABLE_ALWAYS;
 	}
 }

--- a/ttddbg/src/ttddbg_plugin.cc
+++ b/ttddbg/src/ttddbg_plugin.cc
@@ -52,11 +52,21 @@ ttddbg::Plugin::Plugin() :
 		BackwardSingleStepRequest::actionHotkey,
 		nullptr,
 		load_custom_icon(singlestep_png, singlestep_png_length, "PNG")
+	)),
+	m_traceChooserActionDesc(ACTION_DESC_LITERAL_PLUGMOD(
+		OpenTraceChooserAction::actionName,
+		OpenTraceChooserAction::actionLabel,
+		&m_traceChooserAction,
+		this,
+		OpenTraceChooserAction::actionLabel,
+		nullptr,
+		-1
 	))
 {
 	register_action(m_backwardActionDesc);
 	register_action(m_positionChooserActionDesc);
 	register_action(m_backwardSingleActionDesc);
+	register_action(m_traceChooserActionDesc);
 
 	hooks.registerHooks();
 	
@@ -69,6 +79,9 @@ ttddbg::Plugin::~Plugin()
 	unregister_action(m_backwardAction.actionName);
 	unregister_action(m_positionChooserAction.actionName);
 	unregister_action(m_backwardSingleAction.actionName);
+	unregister_action(m_traceChooserAction.actionName);
+
+	hooks.unregisterHooks();
 }
 
 void ttddbg::Plugin::showActions()
@@ -76,6 +89,7 @@ void ttddbg::Plugin::showActions()
 	attach_action_to_toolbar("DebugToolBar", m_backwardActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_backwardSingleActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_positionChooserActionDesc.name);
+	attach_action_to_toolbar("DebugToolBar", m_traceChooserActionDesc.name);
 }
 
 void ttddbg::Plugin::hideActions()
@@ -83,6 +97,7 @@ void ttddbg::Plugin::hideActions()
 	detach_action_from_toolbar("DebugToolBar", m_backwardActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_backwardSingleActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_positionChooserActionDesc.name);
+	detach_action_from_toolbar("DebugToolBar", m_traceChooserActionDesc.name);
 }
 
 /**********************************************************************/

--- a/ttddbg/src/ttddbg_plugin.cc
+++ b/ttddbg/src/ttddbg_plugin.cc
@@ -22,6 +22,7 @@
 #include "ttddbg_debugger_x86_64.hh"
 #include "single_step_icon.hh"
 #include "resume_backwards_icon.hh"
+#include "ttddbg_hooks.hh"
 
 /**********************************************************************/
 ttddbg::Plugin::Plugin() : 
@@ -56,6 +57,8 @@ ttddbg::Plugin::Plugin() :
 	register_action(m_backwardActionDesc);
 	register_action(m_positionChooserActionDesc);
 	register_action(m_backwardSingleActionDesc);
+
+	hooks.registerHooks();
 	
 	//showActions();
 }

--- a/ttddbg/src/ttddbg_plugin.cc
+++ b/ttddbg/src/ttddbg_plugin.cc
@@ -61,12 +61,22 @@ ttddbg::Plugin::Plugin() :
 		OpenTraceChooserAction::actionLabel,
 		nullptr,
 		-1
+	)),
+	m_traceEventChooserActionDesc(ACTION_DESC_LITERAL_PLUGMOD(
+		OpenTraceEventChooserAction::actionName,
+		OpenTraceEventChooserAction::actionLabel,
+		&m_traceEventChooserAction,
+		this, 
+		OpenTraceEventChooserAction::actionLabel,
+		nullptr,
+		-1
 	))
 {
 	register_action(m_backwardActionDesc);
 	register_action(m_positionChooserActionDesc);
 	register_action(m_backwardSingleActionDesc);
 	register_action(m_traceChooserActionDesc);
+	register_action(m_traceEventChooserActionDesc);
 
 	hooks.registerHooks();
 	
@@ -80,6 +90,7 @@ ttddbg::Plugin::~Plugin()
 	unregister_action(m_positionChooserAction.actionName);
 	unregister_action(m_backwardSingleAction.actionName);
 	unregister_action(m_traceChooserAction.actionName);
+	unregister_action(m_traceEventChooserAction.actionName);
 
 	hooks.unregisterHooks();
 }
@@ -90,6 +101,7 @@ void ttddbg::Plugin::showActions()
 	attach_action_to_toolbar("DebugToolBar", m_backwardSingleActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_positionChooserActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_traceChooserActionDesc.name);
+	attach_action_to_toolbar("DebugToolBar", m_traceEventChooserActionDesc.name);
 }
 
 void ttddbg::Plugin::hideActions()
@@ -98,6 +110,7 @@ void ttddbg::Plugin::hideActions()
 	detach_action_from_toolbar("DebugToolBar", m_backwardSingleActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_positionChooserActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_traceChooserActionDesc.name);
+	detach_action_from_toolbar("DebugToolBar", m_traceEventChooserActionDesc.name);
 }
 
 /**********************************************************************/

--- a/ttddbg/src/ttddbg_plugin.cc
+++ b/ttddbg/src/ttddbg_plugin.cc
@@ -25,7 +25,7 @@
 #include "ttddbg_hooks.hh"
 
 /**********************************************************************/
-ttddbg::Plugin::Plugin() : 
+ttddbg::Plugin::Plugin() :
 	m_backwardActionDesc(ACTION_DESC_LITERAL_PLUGMOD(
 		BackwardStateRequest::actionName,
 		BackwardStateRequest::actionLabel,
@@ -34,6 +34,15 @@ ttddbg::Plugin::Plugin() :
 		BackwardStateRequest::actionHotkey,
 		nullptr,
 		load_custom_icon(resumebackwards_png, resumebackwards_png_length, "PNG")
+	)),
+	m_fullRunActionDesc(ACTION_DESC_LITERAL_PLUGMOD(
+		FullRunActionRequest::actionName,
+		FullRunActionRequest::actionLabel,
+		&m_fullRunAction,
+		this,
+		FullRunActionRequest::actionHotkey,
+		nullptr,
+		203
 	)),
 	m_positionChooserActionDesc(ACTION_DESC_LITERAL_PLUGMOD(
 		OpenPositionChooserAction::actionName,
@@ -73,6 +82,7 @@ ttddbg::Plugin::Plugin() :
 	))
 {
 	register_action(m_backwardActionDesc);
+	register_action(m_fullRunActionDesc);
 	register_action(m_positionChooserActionDesc);
 	register_action(m_backwardSingleActionDesc);
 	register_action(m_traceChooserActionDesc);
@@ -87,6 +97,7 @@ ttddbg::Plugin::Plugin() :
 ttddbg::Plugin::~Plugin()
 {
 	unregister_action(m_backwardAction.actionName);
+	unregister_action(m_fullRunAction.actionName);
 	unregister_action(m_positionChooserAction.actionName);
 	unregister_action(m_backwardSingleAction.actionName);
 	unregister_action(m_traceChooserAction.actionName);
@@ -98,6 +109,7 @@ ttddbg::Plugin::~Plugin()
 void ttddbg::Plugin::showActions()
 {
 	attach_action_to_toolbar("DebugToolBar", m_backwardActionDesc.name);
+	attach_action_to_toolbar("DebugToolBar", m_fullRunActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_backwardSingleActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_positionChooserActionDesc.name);
 	attach_action_to_toolbar("DebugToolBar", m_traceChooserActionDesc.name);
@@ -107,6 +119,7 @@ void ttddbg::Plugin::showActions()
 void ttddbg::Plugin::hideActions()
 {
 	detach_action_from_toolbar("DebugToolBar", m_backwardActionDesc.name);
+	detach_action_from_toolbar("DebugToolBar", m_fullRunActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_backwardSingleActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_positionChooserActionDesc.name);
 	detach_action_from_toolbar("DebugToolBar", m_traceChooserActionDesc.name);

--- a/ttddbg/src/ttddbg_plugin.cc
+++ b/ttddbg/src/ttddbg_plugin.cc
@@ -60,7 +60,7 @@ ttddbg::Plugin::Plugin() :
 		this,
 		OpenTraceChooserAction::actionLabel,
 		nullptr,
-		-1
+		128
 	)),
 	m_traceEventChooserActionDesc(ACTION_DESC_LITERAL_PLUGMOD(
 		OpenTraceEventChooserAction::actionName,
@@ -69,7 +69,7 @@ ttddbg::Plugin::Plugin() :
 		this, 
 		OpenTraceEventChooserAction::actionLabel,
 		nullptr,
-		-1
+		73
 	))
 {
 	register_action(m_backwardActionDesc);

--- a/ttddbg/src/ttddbg_position_chooser.cc
+++ b/ttddbg/src/ttddbg_position_chooser.cc
@@ -10,6 +10,7 @@ namespace ttddbg {
 		: chooser_t(CH_CAN_INS | CH_CAN_DEL | CH_KEEP, 2, nullptr, new char* [2]{"Name", "Position"}, "Timeline"), m_cursor(nullptr), m_logger{ logger },m_isClosed(true)
 	{
 		loadPositions();
+		this->icon = 185;
 	}
 
 	/**********************************************************************/

--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -167,6 +167,30 @@ namespace ttddbg {
 					value.sprnt("0x%X", ptr);
 				}
 			}
+			else if (arg.is_enum()) {
+				enum_type_data_t enumDetails;
+				bool ok = arg.get_enum_details(&enumDetails);
+				if (!ok) {
+					warning("Could not get enum details!");
+				}
+				else {
+					int arg_value = 0;
+					if (bitness == BITNESS_x64) {
+						arg_value = x64_getIntArg(&tmpCur, tinfo, i);
+					}
+					else if (bitness == BITNESS_x86) {
+						arg_value = x86_getIntArg(&tmpCur, tinfo, i);
+					}
+
+					for (size_t i = 0; i < enumDetails.size(); i++) {
+						enum_member_t member = enumDetails.at(i);
+						if (member.value == arg_value) {
+							value = member.name;
+							break;
+						}
+					}
+				}
+			}
 				
 			if (value.size() == 0){
 				value = "?";

--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -243,10 +243,6 @@ namespace ttddbg {
 		TTD::Cursor tmpCur = m_engine.NewCursor();
 		tmpCur.SetPosition(&pos);
 
-		qstring mangled_name, func_name;
-		get_func_name(&mangled_name, func->start_ea);
-		func_name = demangle_name(mangled_name.c_str(), 0);
-
 		tinfo_t rettype = tinfo.get_rettype();
 		
 		qstring value;

--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -7,16 +7,38 @@
 
 namespace ttddbg {
 	void callCallback(unsigned __int64 callback_value, TTD::GuestAddress addr_func, TTD::GuestAddress addr_ret, struct TTD::TTD_Replay_IThreadView* thread_view) {
+		if (addr_ret == 0) {
+			return;
+		}
+		
 		if (FunctionTracer::getInstance()->isEATraced(addr_func)) {
 			qstring func_name;
 			get_func_name(&func_name, addr_func);
+			func_t* func = get_func(addr_func);
+			TTD::Position* position = thread_view->IThreadView->GetPosition(thread_view);
 
 			msg("[tracer] called '%s' at 0x%X\n", func_name.c_str(), addr_ret);
+
+			FunctionTracer::getInstance()->recordCall(func, *position);
 		}
 	}
 
+	FunctionTracer* FunctionTracer::c_instance = nullptr;
+
 	FunctionTracer::FunctionTracer() {
 
+	}
+
+	void FunctionTracer::destroy() {
+		if (FunctionTracer::c_instance != nullptr) {
+			FunctionTracer::getInstance()->m_cursor->SetCallReturnCallback(NULL, 0);
+			delete FunctionTracer::c_instance;
+			FunctionTracer::c_instance = NULL;
+		}
+	}
+
+	void FunctionTracer::setNewTraceCallback(std::function<void(func_t*)> f) {
+		m_cbNewTrace = f;
 	}
 
 	FunctionTracer* FunctionTracer::getInstance() {
@@ -38,6 +60,14 @@ namespace ttddbg {
 		
 		msg("[tracer] Tracing function at 0x%X\n", func->start_ea);
 		m_traces.push_back(func->start_ea);
+
+		if (m_cbNewTrace) {
+			m_cbNewTrace(func);
+		}
+	}
+
+	void FunctionTracer::removeTrace(size_t n) {
+		m_traces.erase(m_traces.begin() + n);
 	}
 
 	bool FunctionTracer::isTraced(func_t* func) {
@@ -52,5 +82,31 @@ namespace ttddbg {
 			}
 		}
 		return false;
+	}
+
+	void FunctionTracer::recordCall(func_t* func, TTD::Position pos) {
+		FunctionInvocation ev{ func, pos };
+		m_events.push_back(ev);
+	}
+
+	/*****************************************************************/
+
+	size_t FunctionTracer::countTraced() {
+		return m_traces.size();
+	}
+
+	func_t* FunctionTracer::funcAt(int i) {
+		ea_t ea = m_traces.at(i);
+		return get_func(ea);
+	}
+
+	/*****************************************************************/
+
+	size_t FunctionTracer::countEvents() {
+		return m_events.size();
+	}
+
+	FunctionInvocation FunctionTracer::eventAt(int i) {
+		return m_events.at(i);
 	}
 }

--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -1,0 +1,56 @@
+#include "ttddbg_tracer.hh"
+
+#include <kernwin.hpp>
+#include <pro.h>
+#include <funcs.hpp>
+
+
+namespace ttddbg {
+	void callCallback(unsigned __int64 callback_value, TTD::GuestAddress addr_func, TTD::GuestAddress addr_ret, struct TTD::TTD_Replay_IThreadView* thread_view) {
+		if (FunctionTracer::getInstance()->isEATraced(addr_func)) {
+			qstring func_name;
+			get_func_name(&func_name, addr_func);
+
+			msg("[tracer] called '%s' at 0x%X\n", func_name.c_str(), addr_ret);
+		}
+	}
+
+	FunctionTracer::FunctionTracer() {
+
+	}
+
+	FunctionTracer* FunctionTracer::getInstance() {
+		if (FunctionTracer::c_instance == nullptr) {
+			FunctionTracer::c_instance = new FunctionTracer();
+		}
+
+		return FunctionTracer::c_instance;
+	}
+
+	void FunctionTracer::setCursor(std::shared_ptr<TTD::Cursor> cursor) {
+		m_cursor = cursor;
+		m_cursor->SetCallReturnCallback(&callCallback, 0);
+	}
+
+	void FunctionTracer::traceFunction(func_t *func) {
+		if (isTraced(func))
+			return;
+		
+		msg("[tracer] Tracing function at 0x%X\n", func->start_ea);
+		m_traces.push_back(func->start_ea);
+	}
+
+	bool FunctionTracer::isTraced(func_t* func) {
+		return isEATraced(func->start_ea);
+	}
+
+	bool FunctionTracer::isEATraced(ea_t start) {
+		for (int i = 0; i < m_traces.size(); i++) {
+			ea_t ea = m_traces.at(i);
+			if (ea == start) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -257,19 +257,25 @@ namespace ttddbg {
 
 		qstring clip;
 		tinfo_t arg = tinfo.get_nth_arg(narg);
+		int copy_pointer_contents = ASKBTN_NO;
 		if (arg.is_ptr_or_array()) {
 			// In the case of a pointer: copy the address stored in the pointer
-			unsigned long long ptr = 0;
-			if (bitness == BITNESS_x86) {
-				ptr = x86_getIntArg(&tmpCur, tinfo, narg);
-			}
-			else if (bitness == BITNESS_x64) {
-				ptr = x64_getIntArg(&tmpCur, tinfo, narg);
-			}
+			copy_pointer_contents = ask_yn(ASKBTN_YES, "This argument is a pointer. Do you want to instead copy the address stored in the pointer?");
 
-			clip.sprnt("0x%X", ptr);
+			if (copy_pointer_contents == ASKBTN_YES) {
+				unsigned long long ptr = 0;
+				if (bitness == BITNESS_x86) {
+					ptr = x86_getIntArg(&tmpCur, tinfo, narg);
+				}
+				else if (bitness == BITNESS_x64) {
+					ptr = x64_getIntArg(&tmpCur, tinfo, narg);
+				}
+
+				clip.sprnt("0x%X", ptr);
+			}
 		}
-		else {
+
+		if (copy_pointer_contents == ASKBTN_NO) {
 			// In the case of a stack variable: copy the address of the variable on the stack
 			// Of course, this doesn't work if the variable is not on the stack (__fastcall, x64)
 			if (bitness == BITNESS_x86) {

--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -177,13 +177,14 @@ namespace ttddbg {
 				pointed.print(&pointed_type);
 				pointed_type.replace("const ", "");
 
+				qstring tmp;
 				if (pointed.is_char()) {
-					value = readStringAt(&tmpCur, ptr);
-					value.sprnt("\"%s\"", value.c_str());
+					tmp = readStringAt(&tmpCur, ptr);
+					value.sprnt("\"%s\"", tmp.c_str());
 				}
 				else if (pointed_type == "wchar_t") {
-					value = readWideStringAt(&tmpCur, ptr);
-					value.sprnt("\"%s\"", value.c_str());
+					tmp = readWideStringAt(&tmpCur, ptr);
+					value.sprnt("\"%s\"", tmp.c_str());
 				}
 				else {
 					value.sprnt("0x%X", ptr);
@@ -218,7 +219,8 @@ namespace ttddbg {
 				value = "?";
 			}
 
-			value.sprnt("(%s)%s", type_name.c_str(), value.c_str());
+			qstring tmp = value;
+			value.sprnt("(%s)%s", type_name.c_str(), tmp.c_str());
 			ev.args.push_back(value);
 		}
 			
@@ -278,13 +280,14 @@ namespace ttddbg {
 			pointed.print(&pointed_type);
 			pointed_type.replace("const ", "");
 
+			qstring tmp;
 			if (pointed.is_char()) {
-				value = readStringAt(&tmpCur, ptr);
-				value.sprnt("\"%s\"", value.c_str());
+				tmp = readStringAt(&tmpCur, ptr);
+				value.sprnt("\"%s\"", tmp.c_str());
 			}
 			else if (pointed_type == "wchar_t") {
-				value = readWideStringAt(&tmpCur, ptr);
-				value.sprnt("\"%s\"", value.c_str());
+				tmp = readWideStringAt(&tmpCur, ptr);
+				value.sprnt("\"%s\"", tmp.c_str());
 			}
 			else {
 				value.sprnt("0x%X", ptr);
@@ -319,7 +322,8 @@ namespace ttddbg {
 			value = "?";
 		}
 
-		value.sprnt("(%s)%s", type_name.c_str(), value.c_str());
+		qstring tmp = value;
+		value.sprnt("(%s)%s", type_name.c_str(), tmp.c_str());
 
 		FunctionInvocation ev;
 		ev.pos = pos;
@@ -434,6 +438,27 @@ namespace ttddbg {
 		}
 
 		setClipboardContent(clip);
+	}
+
+	void FunctionTracer::copyReturnValue(size_t nevent) 
+	{
+		FunctionInvocation ev = eventAt(nevent);
+		int bitness = get_func_bitness(ev.func);
+		TTD::Cursor tmpCur = m_engine.NewCursor();
+		tmpCur.SetPosition(&ev.pos);
+
+		unsigned long long ret = 0;
+		if (bitness == BITNESS_x86) {
+			ret = tmpCur.GetContextx86()->Eax;
+		}
+		else if (bitness == BITNESS_x64) {
+			ret = tmpCur.GetContextx86_64()->Rax;
+		}
+
+		qstring out;
+		out.sprnt("0x%X", ret);
+
+		setClipboardContent(out);
 	}
 
 	void FunctionTracer::setClipboardContent(qstring s)

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -2,6 +2,10 @@
 #include "ttddbg_tracer.hh"
 #include "ttddbg_debugger.hh"
 
+#include <name.hpp>
+#include <dbg.hpp>
+#include <kernwin.hpp>
+
 namespace ttddbg {
 	// Function trace list
 	TracerTraceChooser::TracerTraceChooser()
@@ -16,6 +20,7 @@ namespace ttddbg {
 		func_t* func = FunctionTracer::getInstance()->funcAt(n);
 		qstring fname;
 		get_func_name(&fname, func->start_ea);
+		fname = demangle_name(fname.c_str(), 0);
 
 		out->at(0).sprnt(fname.c_str());
 		out->at(1).sprnt("0x%X", func->start_ea);
@@ -24,6 +29,44 @@ namespace ttddbg {
 	chooser_t::cbret_t TracerTraceChooser::del(size_t n) {
 		FunctionTracer::getInstance()->removeTrace(n);
 
+		return ALL_CHANGED;
+	}
+
+	//////////////////////////////////////////////////////////////////////////////////////
+	TracerEventChooser::TracerEventChooser()
+		: chooser_t(CH_KEEP | CH_CAN_DEL, 6, nullptr, new char* [6] {"Position", "Function name", "Arg1", "Arg2", "Arg3", "Arg4"}, "Tracing events")
+	{}
+
+	size_t TracerEventChooser::get_count() const {
+		return FunctionTracer::getInstance()->countEvents();
+	}
+
+	void TracerEventChooser::get_row(qstrvec_t* out, int* out_icon, chooser_item_attrs_t* out_attrs, size_t n) const {
+		FunctionInvocation ev = FunctionTracer::getInstance()->eventAt(n);
+		qstring fname;
+		get_func_name(&fname, ev.func->start_ea);
+		fname = demangle_name(fname.c_str(), 0);
+
+		out->at(0).sprnt("%d %d", ev.pos.Major, ev.pos.Minor);
+		out->at(1).sprnt(fname.c_str());
+		
+		for (int i = 0; i < ev.args.size(); i++) {
+			out->at(i + 2).sprnt("%s", ev.args[i].c_str());
+		}
+
+	}
+
+	ea_t TracerEventChooser::get_ea(size_t n) const {
+		FunctionInvocation ev = FunctionTracer::getInstance()->eventAt(n);
+		
+		static_cast<ttddbg::Debugger*>(dbg)->getManager().setNextPosition(ev.pos);
+		continue_process();
+
+		return BADADDR;
+	}
+
+	chooser_t::cbret_t TracerEventChooser::del(size_t n) {
+		FunctionTracer::getInstance()->removeEvent(n);
 		return ALL_CHANGED;
 	}
 }

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -9,7 +9,7 @@
 namespace ttddbg {
 	// Function trace list
 	TracerTraceChooser::TracerTraceChooser()
-		: chooser_t(CH_CAN_DEL | CH_KEEP, 2, new int[2]{20, 0}, new char* [2] {"Offset", "Function name"}, "Traced functions")
+		: chooser_t(CH_CAN_DEL | CH_KEEP | CH_CAN_INS, 2, new int[2]{20, 0}, new char* [2] {"Offset", "Function name"}, "Traced functions")
 	{}
 
 	size_t TracerTraceChooser::get_count() const {
@@ -32,9 +32,20 @@ namespace ttddbg {
 		return ALL_CHANGED;
 	}
 
+	chooser_t::cbret_t TracerTraceChooser::ins(ssize_t n) {
+		func_t *func = choose_func("Choose function to trace", 0);
+		if (func == nullptr) {
+			return NOTHING_CHANGED;
+		}
+
+		FunctionTracer::getInstance()->traceFunction(func);
+
+		return ALL_CHANGED;
+	}
+
 	//////////////////////////////////////////////////////////////////////////////////////
 	TracerEventChooser::TracerEventChooser()
-		: chooser_t(CH_KEEP | CH_CAN_DEL, 6, new int[6] {20, 200, 50, 50, 50, 50}, new char* [6] {"Position", "Function name", "Arg1", "Arg2", "Arg3", "Arg4"}, "Tracing events")
+		: chooser_t(CH_KEEP | CH_CAN_DEL, 6, new int[6] {20, 0, 50, 50, 50, 50}, new char* [6] {"Position", "Function name", "Arg1", "Arg2", "Arg3", "Arg4"}, "Tracing events")
 	{}
 
 	size_t TracerEventChooser::get_count() const {

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -63,12 +63,13 @@ namespace ttddbg {
 		fname = demangle_name(fname.c_str(), 0);
 
 		out->at(0).sprnt("%d %d", ev.pos.Major, ev.pos.Minor);
+		out->at(1).sprnt("%s", fname.c_str());
 
 		if (ev.is_return) {
-			out->at(1).sprnt("<- %s", fname.c_str());
+			*out_icon = 57;
 		}
 		else {
-			out->at(1).sprnt("%s", fname.c_str());
+			*out_icon = 56;
 		}
 		
 		

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -9,7 +9,7 @@
 namespace ttddbg {
 	// Function trace list
 	TracerTraceChooser::TracerTraceChooser()
-		: chooser_t(CH_CAN_DEL | CH_KEEP, 2, nullptr, new char* [2] {"Function name", "Offset"}, "Traced functions")
+		: chooser_t(CH_CAN_DEL | CH_KEEP, 2, new int[2]{20, 0}, new char* [2] {"Offset", "Function name"}, "Traced functions")
 	{}
 
 	size_t TracerTraceChooser::get_count() const {
@@ -22,8 +22,8 @@ namespace ttddbg {
 		get_func_name(&fname, func->start_ea);
 		fname = demangle_name(fname.c_str(), 0);
 
-		out->at(0).sprnt(fname.c_str());
-		out->at(1).sprnt("0x%X", func->start_ea);
+		out->at(0).sprnt("0x%X", func->start_ea);
+		out->at(1).sprnt(fname.c_str());
 	}
 
 	chooser_t::cbret_t TracerTraceChooser::del(size_t n) {
@@ -34,7 +34,7 @@ namespace ttddbg {
 
 	//////////////////////////////////////////////////////////////////////////////////////
 	TracerEventChooser::TracerEventChooser()
-		: chooser_t(CH_KEEP | CH_CAN_DEL, 6, nullptr, new char* [6] {"Position", "Function name", "Arg1", "Arg2", "Arg3", "Arg4"}, "Tracing events")
+		: chooser_t(CH_KEEP | CH_CAN_DEL, 6, new int[6] {20, 200, 50, 50, 50, 50}, new char* [6] {"Position", "Function name", "Arg1", "Arg2", "Arg3", "Arg4"}, "Tracing events")
 	{}
 
 	size_t TracerEventChooser::get_count() const {
@@ -50,7 +50,7 @@ namespace ttddbg {
 		out->at(0).sprnt("%d %d", ev.pos.Major, ev.pos.Minor);
 		out->at(1).sprnt(fname.c_str());
 		
-		for (int i = 0; i < ev.args.size(); i++) {
+		for (int i = 0; i < min(ev.args.size(), 4); i++) {
 			out->at(i + 2).sprnt("%s", ev.args[i].c_str());
 		}
 

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -10,7 +10,9 @@ namespace ttddbg {
 	// Function trace list
 	TracerTraceChooser::TracerTraceChooser()
 		: chooser_t(CH_CAN_DEL | CH_KEEP | CH_CAN_INS, 2, new int[2]{20, 0}, new char* [2] {"Offset", "Function name"}, "Traced functions")
-	{}
+	{
+		this->icon = 128;
+	}
 
 	size_t TracerTraceChooser::get_count() const {
 		return FunctionTracer::getInstance()->countTraced();
@@ -46,7 +48,9 @@ namespace ttddbg {
 	//////////////////////////////////////////////////////////////////////////////////////
 	TracerEventChooser::TracerEventChooser()
 		: chooser_t(CH_KEEP | CH_CAN_DEL, 6, new int[6] {20, 0, 50, 50, 50, 50}, new char* [6] {"Position", "Function name", "Arg1", "Arg2", "Arg3", "Arg4"}, "Tracing events")
-	{}
+	{
+		this->icon = 73;
+	}
 
 	size_t TracerEventChooser::get_count() const {
 		return FunctionTracer::getInstance()->countEvents();
@@ -59,7 +63,14 @@ namespace ttddbg {
 		fname = demangle_name(fname.c_str(), 0);
 
 		out->at(0).sprnt("%d %d", ev.pos.Major, ev.pos.Minor);
-		out->at(1).sprnt(fname.c_str());
+
+		if (ev.is_return) {
+			out->at(1).sprnt("<- %s", fname.c_str());
+		}
+		else {
+			out->at(1).sprnt("%s", fname.c_str());
+		}
+		
 		
 		for (int i = 0; i < min(ev.args.size(), 4); i++) {
 			out->at(i + 2).sprnt("%s", ev.args[i].c_str());

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -20,9 +20,15 @@ namespace ttddbg {
 
 	void TracerTraceChooser::get_row(qstrvec_t* out, int* out_icon, chooser_item_attrs_t* out_attrs, size_t n) const {
 		func_t* func = FunctionTracer::getInstance()->funcAt(n);
+
 		qstring fname;
 		get_func_name(&fname, func->start_ea);
-		fname = demangle_name(fname.c_str(), 0);
+		qstring demangled;
+		demangled = demangle_name(fname.c_str(), 0);
+
+		if (demangled.size() > 0) {
+			fname = demangled;
+		}
 
 		out->at(0).sprnt("0x%X", func->start_ea);
 		out->at(1).sprnt(fname.c_str());
@@ -60,7 +66,13 @@ namespace ttddbg {
 		FunctionInvocation ev = FunctionTracer::getInstance()->eventAt(n);
 		qstring fname;
 		get_func_name(&fname, ev.func->start_ea);
-		fname = demangle_name(fname.c_str(), 0);
+
+		qstring demangled;
+		demangled = demangle_name(fname.c_str(), 0);
+
+		if (demangled.size() > 0) {
+			fname = demangled;
+		}
 
 		out->at(0).sprnt("%d %d", ev.pos.Major, ev.pos.Minor);
 		out->at(1).sprnt("%s", fname.c_str());

--- a/ttddbg/src/ttddbg_tracer_choosers.cc
+++ b/ttddbg/src/ttddbg_tracer_choosers.cc
@@ -1,0 +1,29 @@
+#include "ttddbg_tracer_choosers.hh"
+#include "ttddbg_tracer.hh"
+#include "ttddbg_debugger.hh"
+
+namespace ttddbg {
+	// Function trace list
+	TracerTraceChooser::TracerTraceChooser()
+		: chooser_t(CH_CAN_DEL | CH_KEEP, 2, nullptr, new char* [2] {"Function name", "Offset"}, "Traced functions")
+	{}
+
+	size_t TracerTraceChooser::get_count() const {
+		return FunctionTracer::getInstance()->countTraced();
+	}
+
+	void TracerTraceChooser::get_row(qstrvec_t* out, int* out_icon, chooser_item_attrs_t* out_attrs, size_t n) const {
+		func_t* func = FunctionTracer::getInstance()->funcAt(n);
+		qstring fname;
+		get_func_name(&fname, func->start_ea);
+
+		out->at(0).sprnt(fname.c_str());
+		out->at(1).sprnt("0x%X", func->start_ea);
+	}
+
+	chooser_t::cbret_t TracerTraceChooser::del(size_t n) {
+		FunctionTracer::getInstance()->removeTrace(n);
+
+		return ALL_CHANGED;
+	}
+}


### PR DESCRIPTION
This PR adds a new feature: function tracing. You can choose to monitor "functions" (i.e. addresses) for calls, and the plugin will automatically use the data stored in the IDB to extract its arguments and return values.