### PR TITLE
fixed the bug where continue backwards did nothing.

### DIFF
--- a/ttddbg/include/ttddbg_debugger_manager.hh
+++ b/ttddbg/include/ttddbg_debugger_manager.hh
@@ -34,6 +34,10 @@ namespace ttddbg
 		};
 
 	protected:
+		/*!
+		 * \brief	maximum steps to simulate backward or forward continuation
+		 */
+		static const int m_maxSteps = -2;
 
 		/*!
 		 * \brief	Current debugger architecture

--- a/ttddbg/src/ttddbg_debugger_manager.cc
+++ b/ttddbg/src/ttddbg_debugger_manager.cc
@@ -290,7 +290,7 @@ namespace ttddbg
 			{
 			case resume_mode_t::RESMOD_NONE:
 			{
-				this->applyCursor(-1);
+				this->applyCursor(m_maxSteps);
 				m_events.addBreakPointEvent(m_processId, m_cursor->GetThreadInfo()[0].threadid, m_cursor->GetProgramCounter());
 				break;
 			}


### PR DESCRIPTION
This commit resolves #14. 

The bug relates to calling _Cursor::ReplayBackward_ with -1 for the _stepCount_ argument. The C++ code examples in the _ttd-bindings_ repository mistakenly calls _Cursor::ReplayForward_ with -1. It should be called with -2. Although _Cursor::ReplayForward_  works normally, using the same argument for _Cursor::ReplayBackward_ does nothing.

The fix can be confirmed by looking at the code for Python bindings in the [ttd-bindings repository.](https://github.com/commial/ttd-bindings/blob/master/python-bindings/module.cpp)

It correctly adds the following line:
`m.attr("MAX_STEP") = 0xFFFFFFFFFFFFFFFE;`
which as an unsigned long equates to -2.

Any calls to continue code execution is then achieved by using _pyTTD.MAX_STEP_ as seen in [example_api.py.](https://github.com/commial/ttd-bindings/blob/master/example_api/example_api.py)