### PR TITLE
IDA version 8.4 change of enum_member_t struct to edm_t in typeinf.hpp

### DIFF
--- a/ttddbg/src/ttddbg_tracer.cc
+++ b/ttddbg/src/ttddbg_tracer.cc
@@ -210,7 +210,7 @@ namespace ttddbg {
 					}
 
 					for (size_t i = 0; i < enumDetails.size(); i++) {
-						enum_member_t member = enumDetails.at(i);
+						edm_t member = enumDetails.at(i);
 						if (member.value == arg_value) {
 							value = member.name;
 							break;
@@ -311,7 +311,7 @@ namespace ttddbg {
 				}
 
 				for (size_t i = 0; i < enumDetails.size(); i++) {
-					enum_member_t member = enumDetails.at(i);
+					edm_t member = enumDetails.at(i);
 					if (member.value == arg_value) {
 						value = member.name;
 						break;


### PR DESCRIPTION
Dear Airbus CERT team, 

`enum_member_t` is not used in IDA SDK v8.4 and was replaced for this version at least by `edm_t`.

Build was created with:
- cmake version 3.27.7
- Windows Installer XML Toolset Compiler version 3.11.2.4516
- build parameters:
  - IDA_SDK_SOURCE_DIR
  - IDA_SDK_PRO
  - CPACK_PACKAGE_INSTALL_DIRECTORY

Build was tested with provided executable and its trace: ttddbg_test_multithread01

Recognition for finding the change is due to Mr. Josh Homan (Manager at Mandiant FLARE).

Thank you for your impressive work on this plugin. I hope to stay in touch!

Kind regards,
Richard